### PR TITLE
Update gallery sizes and make dark theme default

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mario Stroeykens</title>
   </head>
-  <body>
+  <body class="dark">
     <div id="root"></div>
   </body>
 </html>

--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -5,7 +5,7 @@ export const ThemeContext = createContext();
 export const ThemeProvider = ({ children }) => {
   const [darkMode, setDarkMode] = useState(() => {
     const saved = localStorage.getItem('darkMode');
-    return saved ? JSON.parse(saved) : false;
+    return saved ? JSON.parse(saved) : true;
   });
 
   const toggleTheme = () => setDarkMode(prev => !prev);
@@ -18,7 +18,7 @@ export const ThemeProvider = ({ children }) => {
   const theme = darkMode ? 'dark' : 'light';
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ darkMode, theme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -96,6 +96,8 @@ body.dark a:hover {
 /* Gallery Image */
 .gallery-img {
   width: 100%;
+  height: 200px;
+  object-fit: cover;
   transition: transform 0.4s ease;
   border-radius: 0; /* Removed curved corners */
 }

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -7,6 +7,8 @@
 
 .gallery-img {
   width: 100%;
+  height: 200px;
+  object-fit: cover;
   transition: transform 0.4s ease;
 }
 


### PR DESCRIPTION
## Summary
- default dark mode on initial load
- export `darkMode` from context for ThemeToggle
- enforce uniform gallery image sizing
- start the site in dark mode

## Testing
- `npm test --silent` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6840a7c4efd88323824a25bcb79dcc14