### PR TITLE
Improve dark mode and page styles

### DIFF
--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -3,15 +3,24 @@ import { createContext, useState, useEffect } from 'react';
 export const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
-  const [darkMode, setDarkMode] = useState(() => {
-    const saved = localStorage.getItem('darkMode');
-    return saved ? JSON.parse(saved) : true;
-  });
-
-  const toggleTheme = () => setDarkMode(prev => !prev);
+  const [darkMode, setDarkMode] = useState(true);
 
   useEffect(() => {
-    localStorage.setItem('darkMode', JSON.stringify(darkMode));
+    const saved = localStorage.getItem('darkMode');
+    if (saved !== null) {
+      setDarkMode(JSON.parse(saved));
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    setDarkMode(prev => {
+      const updated = !prev;
+      localStorage.setItem('darkMode', JSON.stringify(updated));
+      return updated;
+    });
+  };
+
+  useEffect(() => {
     document.body.className = darkMode ? 'dark' : 'light';
   }, [darkMode]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -130,12 +130,73 @@ body.dark a:hover {
   gap: 1rem;
 }
 
+
 .social-icons img {
-  width: 30px;
-  height: 30px;
+  width: 40px;
+  height: 40px;
   transition: transform 0.3s ease;
 }
 
 .social-icons img:hover {
   transform: scale(1.1);
 }
+
+/* About Page */
+.about {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.about-text h1 {
+  font-size: 2.2rem;
+}
+
+.about-text p {
+  font-size: 1.1rem;
+}
+
+/* Career Page */
+.career {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.career-timeline {
+  margin-top: 1rem;
+  border-left: 2px solid currentColor;
+  padding-left: 1rem;
+}
+
+.career-timeline li {
+  margin-bottom: 0.75rem;
+  position: relative;
+}
+
+.career-timeline li::before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 0.4em;
+  width: 8px;
+  height: 8px;
+  background-color: currentColor;
+  border-radius: 50%;
+}
+
+/* Contact Page */
+.contact {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}
+
+.contact h1 {
+  margin-bottom: 1rem;
+}
+
+.contact p {
+  margin-bottom: 1.5rem;
+}
+


### PR DESCRIPTION
## Summary
- default to dark theme consistently
- refine About, Career, and Contact page layout
- enlarge social icons for Contact page

## Testing
- `npm test --silent` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab6afba88323977886fe4cdf3b9a