### PR TITLE
Add detailed pages and interactions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 
     <meta charset="UTF-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />

--- a/src/assets/icons/nike.svg
+++ b/src/assets/icons/nike.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <path d="M512 128L178 384c-46 32-104 50-178 50 59-38 108-90 152-150L512 128z" fill="currentColor"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap');
 
 * {
   margin: 0;
@@ -7,7 +7,7 @@
 }
 
 html, body {
-  font-family: 'Cormorant Garamond', serif;
+  font-family: 'Montserrat', Helvetica, sans-serif;
   background-color: #f8f8f6;
   color: #111;
   line-height: 1.6;
@@ -93,6 +93,18 @@ body.dark a:hover {
   color: #aaa;
 }
 
+/* Fade-in on scroll */
+.fade-scroll {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.fade-scroll.show {
+  opacity: 1;
+  transform: none;
+}
+
 /* Gallery Image */
 .gallery-img {
   width: 100%;
@@ -104,6 +116,22 @@ body.dark a:hover {
 
 .gallery-img:hover {
   transform: scale(1.04);
+}
+
+/* Buttons */
+.btn {
+  padding: 0.5rem 1rem;
+  background-color: #5b2a91;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn:hover {
+  background-color: #6d3aa5;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
 /* About Page Banner */
@@ -139,6 +167,7 @@ body.dark a:hover {
 
 .social-icons img:hover {
   transform: scale(1.1);
+  box-shadow: 0 0 8px rgba(128, 0, 128, 0.5);
 }
 
 /* About Page */

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,24 +1,48 @@
-import React from "react";
+import React, { useEffect } from "react";
+import heroImage from "../assets/images/14.jpg";
+import headshot from "../assets/images/13.jpg";
 import "../index.css";
-import heroImage from "../assets/images/14.jpg"; // Replace with your preferred image
 
 const About = () => {
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) {
+          e.target.classList.add("show");
+          obs.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    document.querySelectorAll('.fade-scroll').forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="about">
       <div className="about-banner" style={{ backgroundImage: `url(${heroImage})` }}>
-        <div className="about-overlay">
-          <div className="about-text">
-            <h1>Meet Mario Stroeykens</h1>
-            <p>
-              Mario Stroeykens is one of Belgium’s most exciting young footballers. Known for his creativity, agility, and
-              tactical awareness, he plays with a maturity far beyond his years. Whether representing his club or country,
-              Mario is consistently proving himself as a rising star in European football.
-              <br /><br />
-              Off the pitch, Mario is a symbol of ambition, style, and authenticity. From fashion campaigns to community
-              work, his influence is steadily growing—balancing professional discipline with cultural expression.
-            </p>
-          </div>
+        <div className="about-overlay" />
+      </div>
+      <div className="fade-scroll" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', marginTop: '2rem' }}>
+        <div style={{ flex: '1 1 300px' }}>
+          <h1>About Mario Stroeykens</h1>
+          <h2>From Zellik to Purple-and-White: A Story of Heart and Hustle</h2>
         </div>
+        <img src={headshot} alt="Mario Stroeykens smiling" style={{ width: '250px', marginLeft: '1rem', borderRadius: '8px' }} loading="lazy" />
+      </div>
+      <div className="fade-scroll">
+        <p><strong>Born on September 29, 2004, in Zellik, Belgium</strong>, Mario Stroeykens grew up in a sports-loving family with a Belgian father and Congolese mother. From the moment he kicked his first ball, it was clear football ran in his blood. As a young child, Mario joined local side Toekomst Relegem, where coaches noticed his vision, technique, and fearless style on the pitch.</p>
+      </div>
+      <div className="fade-scroll">
+        <p>At age eight, he earned a scholarship to <strong>Anderlecht’s famed youth academy</strong> in Neerpede. Over the next eight years, Mario balanced schoolwork with intense training sessions, developing under legendary coaches and forging friendships with Belgium’s brightest prospects. His maturity and work ethic set him apart even as a teenager.</p>
+      </div>
+      <div className="fade-scroll">
+        <p>In January 2021, just 16 years old, Mario made his professional debut for <strong>RSC Anderlecht</strong> under coach <strong>Vincent Kompany</strong>—one of the youngest debutants in club history. That breakthrough confirmed what fans and staff already suspected: this homegrown talent was destined for big things. Off the field, Mario remains humble, approachable, and always eager to learn.</p>
+      </div>
+      <div className="fade-scroll">
+        <p>When he’s not creating magic on the pitch, Mario is an avid art enthusiast—often spotted exploring Brussels art galleries or sketching in his free time. He speaks French, Dutch, and English fluently, making him a natural leader in the locker room. While deeply focused on his football career, he cares about giving back, frequently visiting youth clinics to inspire the next generation.</p>
+      </div>
+      <div className="fade-scroll">
+        <p>Today, Mario Stroeykens stands as one of Anderlecht’s brightest stars: a midfielder with vision, creativity, and a tireless work rate. With a growing partnership with <strong>Nike</strong> and a spot on Belgium’s youth national teams, his journey is only just beginning. To his fans, coaches, and teammates, Mario represents the perfect blend of talent, humility, and relentless ambition.</p>
       </div>
     </div>
   );

--- a/src/pages/Career.jsx
+++ b/src/pages/Career.jsx
@@ -1,20 +1,68 @@
-import React from "react";
+import React, { useEffect } from "react";
+import actionImg from "../assets/images/12.jpg";
+import nikeIcon from "../assets/icons/nike.svg";
+import "../index.css";
+
+const milestones = [
+  {
+    season: "2020–21: Academy Graduate to First-Team Debut",
+    text: "Joined Anderlecht’s senior squad training under Vincent Kompany. January 15, 2021: Made professional debut at 16 years old in a league match against Eupen. Appeared briefly against Charleroi and Waasland-Beveren; gained valuable experience in top-flight football.",
+    stats: "3 apps"
+  },
+  {
+    season: "2021–22: Learning the Ropes",
+    text: "Featured in eight league matches, primarily as a late substitute. Balanced minutes with U21 appearances to maintain form. Signed first professional contract, extending his stay with Anderlecht until 2024.",
+    stats: "8 apps"
+  },
+  {
+    season: "2022–23: First Senior Goal & Increased Role",
+    text: "October 9, 2022: Scored first senior goal in a 3–1 win at KV Mechelen. Made 20 total appearances, combining first-team and RSCA Futures duty. Gained European experience with minutes in the UEFA Europa Conference League.",
+    stats: "1 goal"
+  },
+  {
+    season: "2023–24: Breakthrough Season",
+    text: "Established himself as a regular starter under coach Brian Riemer. Played 40 matches in all competitions; tallied 6 goals and 6 assists. December 7, 2023: Netted a stunning long-range strike vs Standard Liège in the Belgian Cup, securing a 2–0 victory. Contributed crucial performances that propelled Anderlecht into the championship play-offs.",
+    stats: "6 G / 6 A"
+  },
+  {
+    season: "2024–25: Consistency & Clutch Moments",
+    text: "Cemented his role in Anderlecht’s midfield with 38 league appearances. July 21, 2024: Came off the bench to score a 92nd-minute winner vs STVV on opening day. Represented Belgium U21 at every youth level; captained the U20 side on multiple occasions. Renewed contract through 2026 and featured in UEFA Europa League matches.",
+    stats: "38 apps"
+  }
+];
 
 const Career = () => {
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(e => {
+        if (e.isIntersecting) {
+          e.target.classList.add('show');
+          obs.unobserve(e.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    document.querySelectorAll('.fade-scroll').forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="career">
-      <h1>Career</h1>
-      <p>
-        Mario began his professional journey with R.S.C. Anderlecht, one of Belgium’s most historic clubs.
-        From academy standout to first-team contributor, he has grown into a key midfielder known for his game vision
-        and versatility.
-      </p>
+      <h1 className="fade-scroll">Career Highlights &amp; Milestones</h1>
+      <div className="fade-scroll" style={{ maxWidth: '400px', marginBottom: '1rem' }}>
+        <img src={actionImg} alt="Mario Stroeykens in action" style={{ width: '100%' }} loading="lazy" />
+      </div>
       <ul className="career-timeline">
-        <li><strong>2021:</strong> First Team Debut with Anderlecht</li>
-        <li><strong>2022:</strong> Called up for Belgium U21</li>
-        <li><strong>2023:</strong> Named in "30 Under 30" by Forbes Belgium</li>
-        <li><strong>2024:</strong> Recorded first professional goal in league play</li>
-        <li><strong>Present:</strong> Continuing to develop as a future international talent</li>
+        {milestones.map(m => (
+          <li key={m.season} className="fade-scroll" data-stats={m.stats}>
+            <h3>{m.season}</h3>
+            <p>{m.text}</p>
+          </li>
+        ))}
+        <li className="fade-scroll" style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+          <img src={nikeIcon} alt="Nike" style={{ width: 24, height: 24 }} />
+          <h3 style={{ margin: 0 }}>Nike Partnership</h3>
+          <p style={{ marginTop: '0.5rem' }}>Officially endorsed by Nike since 2023; regularly appears in Nike campaign shoots wearing the latest boots and gear. Demonstrates on-field performance and off-field style, embodying the brand’s “Young &amp; Fearless” ethos.</p>
+        </li>
       </ul>
     </div>
   );

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,23 +1,73 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import instagramIcon from "../assets/icons/instagram.svg";
 import xIcon from "../assets/icons/twitter.svg";
-import youtubeIcon from "../assets/icons/youtube.svg";
 
 const Contact = () => {
+  const [form, setForm] = useState({ name: "", email: "", subject: "", message: "" });
+  const [success, setSuccess] = useState(false);
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('show'); obs.unobserve(e.target);} });
+    }, { threshold: 0.1 });
+    document.querySelectorAll('.fade-scroll').forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const emailValid = /.+@.+\..+/.test(form.email);
+    if (!emailValid) {
+      setErrors({ email: "Please enter a valid email" });
+      return;
+    }
+    setErrors({});
+    setSuccess(true);
+    setForm({ name: "", email: "", subject: "", message: "" });
+  };
+
   return (
     <div className="contact">
-      <h1>Contact</h1>
-      <p>For media inquiries, collaborations, or professional opportunities, feel free to reach out:</p>
-      <div className="social-icons">
+      <h1 className="fade-scroll">Get in Touch</h1>
+      <div className="social-icons fade-scroll">
         <a href="https://instagram.com/m.stroeykens" target="_blank" rel="noopener noreferrer">
           <img src={instagramIcon} alt="Instagram" />
         </a>
-        <a href="https://twitter.com/YOUR_HANDLE" target="_blank" rel="noopener noreferrer">
-          <img src={xIcon} alt="X (Twitter)" />
+        <a href="https://twitter.com/MarioStroeykens" target="_blank" rel="noopener noreferrer">
+          <img src={xIcon} alt="X" />
         </a>
-        <a href="https://youtube.com/YOUR_CHANNEL" target="_blank" rel="noopener noreferrer">
-          <img src={youtubeIcon} alt="YouTube" />
-        </a>
+      </div>
+      <p className="fade-scroll">Whether you’re a fan, a brand partner, or a member of the media, we’d love to hear from you. Drop Mario a message using the form below or connect via social media.</p>
+      <form onSubmit={handleSubmit} className="fade-scroll" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <div>
+          <label>Name</label>
+          <input name="name" value={form.name} onChange={handleChange} required />
+        </div>
+        <div>
+          <label>Email</label>
+          <input name="email" value={form.email} onChange={handleChange} required style={errors.email ? { borderColor: 'red' } : {}} />
+          {errors.email && <small style={{ color: 'red' }}>{errors.email}</small>}
+        </div>
+        <div>
+          <label>Subject</label>
+          <input name="subject" value={form.subject} onChange={handleChange} required />
+        </div>
+        <div>
+          <label>Message</label>
+          <textarea name="message" value={form.message} onChange={handleChange} required rows="4" />
+        </div>
+        <button type="submit" className="btn">Send Message</button>
+        {success && <p>Thanks for your message! We’ll get back to you soon.</p>}
+      </form>
+      <div className="fade-scroll" style={{ marginTop: '1rem' }}>
+        <p>For sponsorships, brand collaborations, or media requests, please reach out to Mario’s management:</p>
+        <p><strong>CAA Stellar</strong></p>
+        <p>For club-related inquiries, you may also contact RSC Anderlecht’s press office via their official website.</p>
       </div>
     </div>
   );

--- a/src/pages/Highlights.jsx
+++ b/src/pages/Highlights.jsx
@@ -1,52 +1,51 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import YouTube from "react-youtube";
+import bg from "../assets/images/10.jpg";
 import "../styles/highlights.css";
 
-const videoData = [
-  {
-    id: "Onwz6V1em98",
-    title: "Stroeykens Scores Against STVV",
-    description: "Mario Stroeykens secures a late victory for RSC Anderlecht against STVV."
-  },
-  {
-    id: "IPGFAr7jJ3o",
-    title: "Belgian Wonderkid Highlights",
-    description: "A compilation of Mario Stroeykens' best moments showcasing his talent."
-  },
-  {
-    id: "NqBh_OGqK7w",
-    title: "Goal vs Lierse",
-    description: "Stroeykens nets a crucial goal in the match against Lierse."
-  },
-  {
-    id: "tvkzzhwHmSw",
-    title: "First Goals for RSC Anderlecht",
-    description: "Watch Mario Stroeykens score his inaugural goals for Anderlecht."
-  }
+const videos = [
+  { id: "Onwz6V1em98", title: "Career Compilation", caption: "All the best plays, goals, and assists in one epic reel." },
+  { id: "NqBh_OGqK7w", title: "First Senior Goal – Oct 9, 2022", caption: "Mario’s composed finish vs KV Mechelen to open his scoring account." },
+  { id: "tvkzzhwHmSw", title: "Cup Stunner vs Standard Liège – Dec 7, 2023", caption: "A 25-yard rocket in the Belgian Cup that left fans speechless." },
+  { id: "Onwz6V1em98", title: "Last-Minute Winner vs STVV – July 21, 2024", caption: "Mario’s 92nd-minute beauty to secure a 1–0 win on opening day." },
+  { id: "IPGFAr7jJ3o", title: "Belgium U21 Highlight", caption: "A glimpse of Mario’s magic on the international stage." }
 ];
 
 const Highlights = () => {
+  const [open, setOpen] = useState(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(e => {
+        if (e.isIntersecting) { e.target.classList.add('show'); obs.unobserve(e.target); }
+      });
+    }, { threshold: 0.1 });
+    document.querySelectorAll('.fade-scroll').forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className="highlights">
-      <h1>Highlights</h1>
-      <div className="video-gallery">
-        {videoData.map((video) => (
-          <div key={video.id} className="video-card">
-            <div className="video-responsive">
-              <iframe
-                width="560"
-                height="315"
-                src={`https://www.youtube.com/embed/${video.id}`}
-                title={video.title}
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowFullScreen
-              ></iframe>
-            </div>
-            <h3>{video.title}</h3>
-            <p>{video.description}</p>
+    <div className="highlights" style={{ backgroundImage: `url(${bg})` }}>
+      <h1 className="fade-scroll">Watch the Best of Mario Stroeykens</h1>
+      <p className="fade-scroll">Explore Mario’s most electrifying moments—from his first senior goal to jaw-dropping match-winners. Click any clip to relive the action in full.</p>
+      <div className="video-grid">
+        {videos.map(v => (
+          <div key={v.title} className="thumb fade-scroll" onClick={() => setOpen(v)}>
+            <img src={`https://img.youtube.com/vi/${v.id}/hqdefault.jpg`} alt={v.title} loading="lazy" />
+            <span className="play">▶</span>
+            <h3>{v.title}</h3>
+            <p>{v.caption}</p>
           </div>
         ))}
       </div>
+      {open && (
+        <div className="lightbox" onClick={() => setOpen(null)}>
+          <YouTube videoId={open.id} opts={{ width: '80%', height: '60%' }} />
+        </div>
+      )}
+      <p className="fade-scroll" style={{ marginTop: '1rem' }}>
+        Subscribe to <a href="https://www.youtube.com" target="_blank" rel="noopener noreferrer">Mario’s official YouTube channel</a> for more highlights.
+      </p>
     </div>
   );
 };

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -52,4 +52,5 @@
 
 .hero-btn:hover {
   background-color: rgba(255,255,255,0.4);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
 }

--- a/src/styles/highlights.css
+++ b/src/styles/highlights.css
@@ -1,30 +1,53 @@
 .highlights {
-    padding: 2rem;
-  }
-  
-  .video-gallery {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-  }
-  
-  .video-card {
-    flex: 1 1 300px;
-    max-width: 500px;
-  }
-  
-  .video-responsive {
-    position: relative;
-    padding-bottom: 56.25%; /* 16:9 aspect ratio */
-    height: 0;
-    overflow: hidden;
-  }
-  
-  .video-responsive iframe {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-  
+  padding: 2rem;
+  background-size: cover;
+  background-attachment: fixed;
+  background-position: center;
+}
+
+.video-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.thumb {
+  position: relative;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+}
+
+.thumb img {
+  width: 100%;
+  display: block;
+}
+
+.thumb .play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2rem;
+  color: white;
+  pointer-events: none;
+}
+
+.thumb:hover {
+  transform: scale(1.05);
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.lightbox iframe {
+  max-width: 90vw;
+}


### PR DESCRIPTION
## Summary
- switch site fonts to Montserrat
- add fade-in-on-scroll animation and button styles
- rework About, Career, Highlights and Contact pages with provided copy
- add Nike icon asset
- create responsive video grid with lightbox

## Testing
- `npm test` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6841d34bc4748323b615bcd0b2c1c535