### PR TITLE
Implement mobile carousels and top ribbon menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Career from "./pages/Career";
 import Highlights from "./pages/Highlights";
 import Contact from "./pages/Contact";
 import Sidebar from "./components/Sidebar";
+import menuIcon from './assets/images/54206.png';
 import "./index.css";
 
 function App() {
@@ -25,8 +26,10 @@ function App() {
 
   return (
     <div className="app">
-      <button className="hamburger" onClick={() => setMenuOpen(true)}>☰</button>
-      <Sidebar open={menuOpen} onToggle={() => setMenuOpen(false)} />
+      <button className="hamburger" onClick={() => setMenuOpen(!menuOpen)}>
+        <img src={menuIcon} alt="Menu" />
+      </button>
+      <Sidebar open={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
       <div className="main-content">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/ImageCarousel.jsx
+++ b/src/components/ImageCarousel.jsx
@@ -1,0 +1,35 @@
+import React, { useRef, useState, useEffect } from 'react';
+import '../styles/carousel.css';
+
+const ImageCarousel = ({ images, className = '' }) => {
+  const containerRef = useRef(null);
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const onScroll = () => {
+      const i = Math.round(container.scrollLeft / container.clientWidth);
+      setIndex(i);
+    };
+    container.addEventListener('scroll', onScroll);
+    return () => container.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <div className={`carousel ${className}`}>
+      <div className="carousel-track" ref={containerRef}>
+        {images.map((img, i) => (
+          <img key={i} src={img} alt="" className="carousel-img" />
+        ))}
+      </div>
+      <div className="carousel-dots">
+        {images.map((_, i) => (
+          <span key={i} className={i === index ? 'active' : ''}></span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ImageCarousel;

--- a/src/components/OnOffFieldGallery.jsx
+++ b/src/components/OnOffFieldGallery.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import '../styles/gallery.css';
+import ImageCarousel from './ImageCarousel';
 import img1 from '../assets/images/1.jpg';
 import img2 from '../assets/images/2.jpg';
 import img3 from '../assets/images/3.jpg';
@@ -14,21 +15,11 @@ const OnOffFieldGallery = () => {
     <div>
       <section>
         <h2>On the Field</h2>
-        <div className="gallery-grid">
-          <img src={img1} alt="On Field 1" className="gallery-img" />
-          <img src={img2} alt="On Field 2" className="gallery-img" />
-          <img src={img3} alt="On Field 3" className="gallery-img" />
-          <img src={img4} alt="On Field 4" className="gallery-img" />
-        </div>
+        <ImageCarousel images={[img1, img2, img3, img4]} className="on-field" />
       </section>
       <section>
         <h2>Off the Field</h2>
-        <div className="gallery-grid">
-          <img src={img5} alt="Off Field 1" className="gallery-img" />
-          <img src={img6} alt="Off Field 2" className="gallery-img" />
-          <img src={img7} alt="Off Field 3" className="gallery-img" />
-          <img src={img8} alt="Off Field 4" className="gallery-img" />
-        </div>
+        <ImageCarousel images={[img5, img6, img7, img8]} className="off-field" />
       </section>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,13 @@ html, body {
 
 .hamburger {
   display: none;
+  background: none;
+  border: none;
+  padding: 0;
+}
+.hamburger img {
+  width: 32px;
+  height: 32px;
 }
 
 .main-content {
@@ -34,11 +41,15 @@ html, body {
 
 @media (max-width: 768px) {
   .sidebar {
-    transform: translateX(-100%);
+    width: 100%;
+    height: auto;
+    top: 0;
+    left: 0;
+    transform: translateY(-100%);
     transition: transform 0.3s ease;
   }
   .sidebar.open {
-    transform: translateX(0);
+    transform: translateY(0);
   }
   .sidebar .close-btn {
     display: block;
@@ -46,11 +57,8 @@ html, body {
   .hamburger {
     position: fixed;
     left: 1rem;
-    top: 1rem;
+    top: 0.5rem;
     z-index: 1100;
-    font-size: 1.5rem;
-    background: none;
-    border: none;
     cursor: pointer;
     display: block;
   }
@@ -238,6 +246,11 @@ body.dark a:hover {
 
 .about-text p {
   font-size: 1.1rem;
+  line-height: 1.7;
+  margin-top: 1rem;
+}
+.about-text p:first-child {
+  margin-top: 0;
 }
 
 /* Career Page */

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import '../styles/gallery.css';
 import Hero from '../components/Hero';
+import ImageCarousel from '../components/ImageCarousel';
 import img1 from '../assets/images/1.jpg';
 import img2 from '../assets/images/2.jpg';
 import img3 from '../assets/images/3.jpg';
@@ -26,21 +27,17 @@ const Home = () => {
       <Hero />
       <section id="see-more" className="fade-scroll">
         <h2>On the Field</h2>
-        <div className="gallery-grid on-field fade-scroll">
-          <img src={img1} alt="On Field 1" className="gallery-img" />
-          <img src={img2} alt="On Field 2" className="gallery-img" />
-          <img src={img3} alt="On Field 3" className="gallery-img" />
-          <img src={img4} alt="On Field 4" className="gallery-img" />
-        </div>
+        <ImageCarousel
+          images={[img1, img2, img3, img4]}
+          className="on-field"
+        />
       </section>
       <section className="fade-scroll">
         <h2>Off the Field</h2>
-        <div className="gallery-grid off-field fade-scroll">
-          <img src={img5} alt="Off Field 1" className="gallery-img" />
-          <img src={img6} alt="Off Field 2" className="gallery-img" />
-          <img src={img7} alt="Off Field 3" className="gallery-img" />
-          <img src={img8} alt="Off Field 4" className="gallery-img" />
-        </div>
+        <ImageCarousel
+          images={[img5, img6, img7, img8]}
+          className="off-field"
+        />
       </section>
     </div>
   );

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,0 +1,51 @@
+.carousel-track {
+  display: flex;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.carousel-track::-webkit-scrollbar {
+  display: none;
+}
+.carousel-img {
+  flex: 0 0 100%;
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  scroll-snap-align: center;
+}
+.carousel-dots {
+  display: flex;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+.carousel-dots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #999;
+  margin: 0 4px;
+}
+.carousel-dots span.active {
+  background: #333;
+}
+@media (min-width: 481px) {
+  .carousel-track {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+  .carousel-img {
+    flex: none;
+  }
+  .carousel-dots {
+    display: none;
+  }
+}
+.carousel.off-field .carousel-img {
+  width: 400px;
+  height: 600px;
+  object-fit: contain;
+  padding: 0.5rem;
+  box-sizing: border-box;
+}

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -13,8 +13,11 @@
 }
 
 .off-field .gallery-img {
-  height: auto;
+  width: 400px;
+  height: 600px;
   object-fit: contain;
+  padding: 0.5rem;
+  box-sizing: border-box;
 }
 
 .gallery-img:hover {


### PR DESCRIPTION
## Summary
- create generic `ImageCarousel` component with pagination dots
- add carousel styles and update Home and Gallery pages to use it
- adjust off-field thumbnail sizing
- tweak About page paragraph spacing
- redesign sidebar as top ribbon menu on mobile and hook up hamburger icon

## Testing
- `npm test` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6847027cec5083238009cd15ed4e1da0