### PR TITLE
Improve mobile layout with header and carousels

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,30 +6,32 @@ import Career from "./pages/Career";
 import Highlights from "./pages/Highlights";
 import Contact from "./pages/Contact";
 import Sidebar from "./components/Sidebar";
-import menuIcon from './assets/images/54206.png';
+import Header from "./components/Header";
+import MobileMenu from "./components/MobileMenu";
 import "./index.css";
 
 function App() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [width, setWidth] = useState(window.innerWidth);
+
   useEffect(() => {
-    const onResize = () => {
-      if (window.innerWidth >= 768) {
-        setMenuOpen(true);
-      } else {
-        setMenuOpen(false);
-      }
-    };
-    onResize();
+    const onResize = () => setWidth(window.innerWidth);
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  const isMobile = width < 768;
+
   return (
     <div className="app">
-      <button className="hamburger" onClick={() => setMenuOpen(!menuOpen)}>
-        <img src={menuIcon} alt="Menu" />
-      </button>
-      <Sidebar open={menuOpen} onToggle={() => setMenuOpen(!menuOpen)} />
+      {isMobile ? (
+        <Header onMenuToggle={() => setMenuOpen(!menuOpen)} />
+      ) : (
+        <Sidebar open />
+      )}
+      {isMobile && (
+        <MobileMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
+      )}
       <div className="main-content">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import logo from '../assets/images/logo.png';
+import menuIcon from '../assets/images/54206.png';
+
+const Header = ({ onMenuToggle }) => (
+  <header className="mobile-header">
+    <img src={logo} alt="MS" className="header-logo" />
+    <button className="hamburger" onClick={onMenuToggle}>
+      <img src={menuIcon} alt="Menu" />
+    </button>
+  </header>
+);
+
+export default Header;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -6,15 +6,17 @@ import heroPoster from '../assets/mario-hero.jpg';
 const Hero = () => {
   return (
     <section className="hero">
-      <video
-        className="hero-video"
-        src={heroVideo}
-        autoPlay
-        loop
-        muted
-        playsInline
-        poster={heroPoster}
-      />
+      <div className="video-wrapper">
+        <video
+          className="hero-video"
+          src={heroVideo}
+          autoPlay
+          loop
+          muted
+          playsInline
+          poster={heroPoster}
+        />
+      </div>
       <div className="hero-overlay" />
       <div className="hero-content">
         <h1>Mario Stroeykens</h1>

--- a/src/components/MobileMenu.jsx
+++ b/src/components/MobileMenu.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const MobileMenu = ({ open, onClose }) => {
+  const handle = () => onClose();
+  return (
+    <div className={`mobile-menu${open ? ' open' : ''}`} onClick={onClose}>
+      <nav onClick={e => e.stopPropagation()}>
+        <NavLink to="/" end onClick={handle}>Home</NavLink>
+        <NavLink to="/about" onClick={handle}>About</NavLink>
+        <NavLink to="/career" onClick={handle}>Career</NavLink>
+        <NavLink to="/highlights" onClick={handle}>Highlights</NavLink>
+        <NavLink to="/contact" onClick={handle}>Contact</NavLink>
+      </nav>
+    </div>
+  );
+};
+
+export default MobileMenu;

--- a/src/index.css
+++ b/src/index.css
@@ -15,10 +15,25 @@ html, body {
   background-color: #f8f8f6;
   color: #111;
   line-height: 1.6;
+  font-size: 16px;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+p {
+  margin-bottom: 1rem;
+  line-height: 1.6;
 }
 
 .app {
   display: flex;
+}
+
+.mobile-header {
+  display: none;
 }
 
 .hamburger {
@@ -37,34 +52,75 @@ html, body {
   padding: 2rem;
   flex: 1;
   min-height: 100vh;
+  width: 100%;
 }
 
 @media (max-width: 768px) {
+  .app {
+    flex-direction: column;
+  }
   .sidebar {
-    width: 100%;
-    height: auto;
+    display: none;
+  }
+  .mobile-header {
+    display: flex;
+    position: fixed;
     top: 0;
     left: 0;
-    transform: translateY(-100%);
-    transition: transform 0.3s ease;
+    width: 100vw;
+    height: 56px;
+    background: #333;
+    color: #fff;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 1rem;
+    z-index: 2000;
   }
-  .sidebar.open {
-    transform: translateY(0);
-  }
-  .sidebar .close-btn {
-    display: block;
+  .header-logo {
+    height: 32px;
   }
   .hamburger {
-    position: fixed;
-    left: 1rem;
-    top: 0.5rem;
-    z-index: 1100;
-    cursor: pointer;
     display: block;
+    background: none;
+    border: none;
+    padding: 0;
   }
   .main-content {
     margin-left: 0;
     padding: 1rem;
+    padding-top: 56px;
+  }
+  .mobile-menu {
+    position: fixed;
+    top: 56px;
+    left: 0;
+    width: 100vw;
+    height: calc(100vh - 56px);
+    background: rgba(0,0,0,0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translateY(-100%);
+    transition: transform 0.2s ease-in;
+    z-index: 1999;
+  }
+  .mobile-menu.open {
+    transform: translateY(0);
+  }
+  .mobile-menu nav {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+    max-width: 300px;
+    text-align: center;
+  }
+  .mobile-menu a {
+    color: #fff;
+    text-decoration: none;
+    font-size: 1.25rem;
+    padding: 12px 0;
+    min-height: 48px;
   }
 }
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -25,6 +25,7 @@ const Home = () => {
   return (
     <div>
       <Hero />
+      <div className="hero-divider" />
       <section id="see-more" className="fade-scroll">
         <h2>On the Field</h2>
         <ImageCarousel

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -8,9 +8,9 @@
   display: none;
 }
 .carousel-img {
-  flex: 0 0 100%;
-  width: 100%;
-  height: 200px;
+  flex: 0 0 300px;
+  width: 300px;
+  height: 400px;
   object-fit: cover;
   scroll-snap-align: center;
 }
@@ -43,8 +43,6 @@
   }
 }
 .carousel.off-field .carousel-img {
-  width: 400px;
-  height: 600px;
   object-fit: contain;
   padding: 0.5rem;
   box-sizing: border-box;

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,8 +1,14 @@
 .hero {
   position: relative;
-  width: 100%;
+  width: 100vw;
   height: 100vh;
   overflow: hidden;
+  box-shadow: 0 4px 4px rgba(0,0,0,0.2);
+}
+.hero .video-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .hero-video {
@@ -53,4 +59,24 @@
 .hero-btn:hover {
   background-color: rgba(255,255,255,0.4);
   box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+}
+
+.hero-divider {
+  width: 100%;
+  height: 2px;
+  background: rgba(0,0,0,0.2);
+}
+
+@media (max-width: 768px) {
+  .hero {
+    height: auto;
+  }
+  .hero .video-wrapper {
+    padding-bottom: 56.25%;
+    height: 0;
+  }
+  .hero-overlay,
+  .hero-content {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add fixed mobile header and slide-down menu
- update `App` to show the new mobile menu
- restructure hero section for landscape video
- apply mobile-first portrait styles and carousel sizing

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68470b3eaad083238d55c3eb2758a339