### PR TITLE
Improve mobile navigation behavior and styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Contact from "./pages/Contact";
 import Sidebar from "./components/Sidebar";
 import Header from "./components/Header";
 import MobileMenu from "./components/MobileMenu";
+import ScrollToTop from "./components/ScrollToTop";
 import "./index.css";
 
 function App() {
@@ -33,6 +34,7 @@ function App() {
         <MobileMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
       )}
       <div className="main-content">
+        <ScrollToTop />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />

--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,7 @@ p {
 .hamburger img {
   width: 32px;
   height: 32px;
+  filter: invert(1);
 }
 
 .main-content {
@@ -69,7 +70,7 @@ p {
     left: 0;
     width: 100vw;
     height: 56px;
-    background: #333;
+    background: #000;
     color: #fff;
     align-items: center;
     justify-content: space-between;
@@ -296,6 +297,15 @@ body.dark a:hover {
   margin: 0 auto;
 }
 
+.about h2 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+}
+
+.about p {
+  line-height: 1.7;
+}
+
 .about-text h1 {
   font-size: 2.2rem;
 }
@@ -323,7 +333,7 @@ body.dark a:hover {
 }
 
 .career-timeline li {
-  margin-bottom: 0.75rem;
+  margin-bottom: 1rem;
   position: relative;
 }
 
@@ -332,9 +342,9 @@ body.dark a:hover {
   position: absolute;
   left: -6px;
   top: 0.4em;
-  width: 8px;
-  height: 8px;
-  background-color: currentColor;
+  width: 6px;
+  height: 6px;
+  background-color: #d4af37;
   border-radius: 50%;
 }
 

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -17,26 +17,18 @@ const About = () => {
 
   return (
     <div className="about">
-      <div className="fade-scroll" style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', marginTop: '2rem' }}>
-        <div style={{ flex: '1 1 300px' }}>
-          <h1>About Mario Stroeykens</h1>
-        </div>
-      </div>
-      <div className="fade-scroll">
+      <h1 className="fade-scroll">About Mario Stroeykens</h1>
+      <section className="fade-scroll">
+        <h2>Who Is Mario?</h2>
         <p><strong>Born on September 29, 2004, in Zellik, Belgium</strong>, Mario Stroeykens grew up in a sports-loving family with a Belgian father and Congolese mother. From the moment he kicked his first ball, it was clear football ran in his blood. As a young child, Mario joined local side Toekomst Relegem, where coaches noticed his vision, technique, and fearless style on the pitch.</p>
-      </div>
-      <div className="fade-scroll">
         <p>At age eight, he earned a scholarship to <strong>Anderlecht’s famed youth academy</strong> in Neerpede. Over the next eight years, Mario balanced schoolwork with intense training sessions, developing under legendary coaches and forging friendships with Belgium’s brightest prospects. His maturity and work ethic set him apart even as a teenager.</p>
-      </div>
-      <div className="fade-scroll">
+      </section>
+      <section className="fade-scroll">
+        <h2>Journey &amp; Highlights</h2>
         <p>In January 2021, just 16 years old, Mario made his professional debut for <strong>RSC Anderlecht</strong> under coach <strong>Vincent Kompany</strong>—one of the youngest debutants in club history. That breakthrough confirmed what fans and staff already suspected: this homegrown talent was destined for big things. Off the field, Mario remains humble, approachable, and always eager to learn.</p>
-      </div>
-      <div className="fade-scroll">
         <p>When he’s not creating magic on the pitch, Mario is an avid art enthusiast—often spotted exploring Brussels art galleries or sketching in his free time. He speaks French, Dutch, and English fluently, making him a natural leader in the locker room. While deeply focused on his football career, he cares about giving back, frequently visiting youth clinics to inspire the next generation.</p>
-      </div>
-      <div className="fade-scroll">
         <p>Today, Mario Stroeykens stands as one of Anderlecht’s brightest stars: a midfielder with vision, creativity, and a tireless work rate. With a growing partnership with <strong>Nike</strong> and a spot on Belgium’s youth national teams, his journey is only just beginning. To his fans, coaches, and teammates, Mario represents the perfect blend of talent, humility, and relentless ambition.</p>
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -70,6 +70,7 @@
 @media (max-width: 768px) {
   .hero {
     height: auto;
+    padding-top: 56px;
   }
   .hero .video-wrapper {
     padding-bottom: 56.25%;


### PR DESCRIPTION
## Summary
- add ScrollToTop helper so each navigation resets scroll
- adjust mobile header to use black background and invert menu icon
- ensure hero section has offset below the header on mobile
- restructure About page with subsections
- refine career bullet style spacing and color

## Testing
- `npm test` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684711619998832390286c6fa681992f