### PR TITLE
Restore hero elements and overlay

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -4,6 +4,10 @@ import heroVideo from '../assets/images/mariovideo/mariovideo.mp4';
 import heroPoster from '../assets/mario-hero.jpg';
 
 const Hero = () => {
+  const handleSeeMore = () => {
+    document.getElementById('see-more')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
   return (
     <section className="hero">
       <div className="video-wrapper">
@@ -21,7 +25,9 @@ const Hero = () => {
       <div className="hero-content">
         <h1>Mario Stroeykens</h1>
         <p>Official Website</p>
-        <a href="#see-more" className="hero-btn">See More</a>
+        <button type="button" className="hero-btn" onClick={handleSeeMore}>
+          See More
+        </button>
       </div>
     </section>
   );

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -18,6 +18,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  object-position: center center;
 }
 
 .hero-overlay {
@@ -76,8 +77,11 @@
     padding-bottom: 56.25%;
     height: 0;
   }
-  .hero-overlay,
+  .hero-overlay {
+    display: block;
+  }
+
   .hero-content {
-    display: none;
+    display: flex;
   }
 }


### PR DESCRIPTION
## Summary
- show hero heading and See More button again
- keep overlay on mobile
- ensure video is centered and cropping stays consistent
- use button with smooth scroll functionality

## Testing
- `npm test --silent` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6847241c59888323b143cf39cd75434a