### PR TITLE
Fix hero overlays and gallery layout

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -5,7 +5,15 @@ import heroPoster from '../assets/mario-hero.jpg';
 
 const Hero = () => {
   const handleSeeMore = () => {
-    document.getElementById('see-more')?.scrollIntoView({ behavior: 'smooth' });
+    if (window.innerWidth <= 768) {
+      const target = document.getElementById('see-more');
+      if (target) {
+        const y = target.getBoundingClientRect().top + window.pageYOffset - 56;
+        window.scrollTo({ top: y, behavior: 'smooth' });
+      }
+    } else {
+      window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+    }
   };
 
   return (

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,3 +1,8 @@
+.carousel {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 .carousel-track {
   display: flex;
   overflow-x: auto;
@@ -37,6 +42,7 @@
   }
   .carousel-img {
     flex: none;
+    width: 100%;
   }
   .carousel-dots {
     display: none;

--- a/src/styles/gallery.css
+++ b/src/styles/gallery.css
@@ -5,6 +5,10 @@
   margin-top: 1rem;
 }
 
+#see-more {
+  scroll-margin-top: 56px;
+}
+
 .gallery-img {
   width: 100%;
   height: 200px;

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -29,9 +29,9 @@
 }
 
 .hero-content {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 2;
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -70,17 +70,16 @@
 
 @media (max-width: 768px) {
   .hero {
-    height: auto;
+    height: calc(100vh - 56px);
     padding-top: 56px;
   }
   .hero .video-wrapper {
-    padding-bottom: 56.25%;
-    height: 0;
+    height: 100%;
+    padding-bottom: 0;
   }
   .hero-overlay {
     display: block;
   }
-
   .hero-content {
     display: flex;
   }


### PR DESCRIPTION
## Summary
- overlay hero content directly on the video
- scroll to bottom on desktop and to the gallery on mobile
- size hero video properly on mobile
- center gallery and constrain width
- offset `see-more` section for mobile header

## Testing
- `npm test --silent -- -w 1 --watchAll=false` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684727c760c083239e05986ac273cd93