### PR TITLE
Center hero text and galleries

### DIFF
--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,5 +1,11 @@
+.carousel {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 .carousel-track {
   display: flex;
+  gap: 1rem;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -7,8 +7,9 @@
 }
 .hero .video-wrapper {
   position: relative;
-  width: 100%;
+  width: 100vw;
   height: 100%;
+  overflow: hidden;
 }
 
 .hero-video {
@@ -38,7 +39,7 @@
   align-items: center;
   text-align: center;
   color: #fff;
-  padding: 0 1rem;
+  padding: 0;
 }
 
 .hero-content h1 {


### PR DESCRIPTION
## Summary
- center hero overlay text with no side padding
- make hero video wrapper span full screen width and hide overflow
- center gallery carousels with a max width and spacing

## Testing
- `npm test --silent` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68473931026083238ff14b16e032a6fd