### PR TITLE
Center hero text and galleries

### DIFF
--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -1,5 +1,11 @@
+.carousel {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 .carousel-track {
   display: flex;
+  gap: 1rem;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,6 +1,6 @@
 .hero {
   position: relative;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   overflow: hidden;
   box-shadow: 0 4px 4px rgba(0,0,0,0.2);
@@ -9,6 +9,7 @@
   position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .hero-video {
@@ -29,7 +30,8 @@
 }
 
 .hero-content {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 2;
   height: 100%;
   display: flex;
@@ -38,7 +40,7 @@
   align-items: center;
   text-align: center;
   color: #fff;
-  padding: 0 1rem;
+  padding: 0;
 }
 
 .hero-content h1 {
@@ -70,12 +72,12 @@
 
 @media (max-width: 768px) {
   .hero {
-    height: auto;
+    height: calc(100vh - 56px);
     padding-top: 56px;
   }
   .hero .video-wrapper {
-    padding-bottom: 56.25%;
-    height: 0;
+    height: 100%;
+    padding-bottom: 0;
   }
   .hero-overlay {
     display: block;


### PR DESCRIPTION
## Summary
- center hero overlay text with no side padding
- make hero video wrapper span full screen width and hide overflow
- center gallery carousels with a max width and spacing
- overlay hero text on video and fix mobile view

## Testing
- `npm test --silent` *(fails: npm command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473931026083238ff14b16e032a6fd