### PR TITLE
Fix hero overlay position and responsive images

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,10 +50,10 @@ p {
 
 .main-content {
   margin-left: 260px;
+  width: calc(100vw - 260px);
   padding: 2rem;
   flex: 1;
   min-height: 100vh;
-  width: 100%;
 }
 
 @media (max-width: 768px) {
@@ -88,6 +88,7 @@ p {
   }
   .main-content {
     margin-left: 0;
+    width: 100vw;
     padding: 1rem;
     padding-top: 56px;
   }

--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -8,9 +8,11 @@
   display: none;
 }
 .carousel-img {
-  flex: 0 0 300px;
-  width: 300px;
-  height: 400px;
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+  max-height: 400px;
   object-fit: cover;
   scroll-snap-align: center;
 }
@@ -46,4 +48,6 @@
   object-fit: contain;
   padding: 0.5rem;
   box-sizing: border-box;
+  max-width: 300px;
+  max-height: 450px;
 }

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,13 +1,13 @@
 .hero {
   position: relative;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   overflow: hidden;
   box-shadow: 0 4px 4px rgba(0,0,0,0.2);
 }
 .hero .video-wrapper {
   position: relative;
-  width: 100vw;
+  width: 100%;
   height: 100%;
 }
 
@@ -29,12 +29,13 @@
 }
 
 .hero-content {
-  position: relative;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 2;
-  height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
   text-align: center;
   color: #fff;
@@ -83,5 +84,11 @@
 
   .hero-content {
     display: flex;
+  }
+}
+
+@media (min-width: 769px) {
+  .hero-content {
+    left: calc(50vw - 260px);
   }
 }


### PR DESCRIPTION
## Summary
- center hero text over the video
- ensure video fits within main content width
- keep hero content centered with sidebar space
- make gallery images responsive

## Testing
- `npm test --silent` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68474d785288832391041f030bbfe3b9