### PR TITLE
Fix hero video layout and uniform off-field images

### DIFF
--- a/src/styles/carousel.css
+++ b/src/styles/carousel.css
@@ -43,7 +43,6 @@
   }
 }
 .carousel.off-field .carousel-img {
-  object-fit: contain;
-  padding: 0.5rem;
-  box-sizing: border-box;
+  object-fit: cover;
+  padding: 0;
 }

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -29,9 +29,9 @@
 }
 
 .hero-content {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 2;
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
## Summary
- keep hero text overlay centered by positioning the hero content absolutely
- make off field carousel images use `object-fit: cover` so their sizes match

## Testing
- `npm test --silent` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684752afcef083239548dfd1f4cbc4ed