### PR TITLE
Fix hero layout on desktop and mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -50,10 +50,10 @@ p {
 
 .main-content {
   margin-left: 260px;
+  width: calc(100% - 260px);
   padding: 2rem;
   flex: 1;
   min-height: 100vh;
-  width: 100%;
 }
 
 @media (max-width: 768px) {
@@ -88,6 +88,7 @@ p {
   }
   .main-content {
     margin-left: 0;
+    width: 100%;
     padding: 1rem;
     padding-top: 56px;
   }

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,13 +1,13 @@
 .hero {
   position: relative;
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   overflow: hidden;
   box-shadow: 0 4px 4px rgba(0,0,0,0.2);
 }
 .hero .video-wrapper {
   position: relative;
-  width: 100vw;
+  width: 100%;
   height: 100%;
 }
 
@@ -70,12 +70,12 @@
 
 @media (max-width: 768px) {
   .hero {
-    height: auto;
-    padding-top: 56px;
+    height: 100vh;
+    padding-top: 0;
   }
   .hero .video-wrapper {
-    padding-bottom: 56.25%;
-    height: 0;
+    padding-bottom: 0;
+    height: 100%;
   }
   .hero-overlay {
     display: block;


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling caused by hero
- fix video wrapper sizing for mobile

## Testing
- `npm test` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684b188832c88323aeda95c2db42942b