### PR TITLE
Fix Highlights hero video

### DIFF
--- a/src/pages/Highlights.jsx
+++ b/src/pages/Highlights.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import YouTube from "react-youtube";
 import "../styles/highlights.css";
+import "../styles/hero.css"; // ensure hero background video displays
 import highlightVideo from "../assets/images/mariovideo/mariohighlights.mp4";
 import heroPoster from "../assets/mario-hero.jpg";
 


### PR DESCRIPTION
## Summary
- ensure hero video styling is applied on Highlights page

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684efbdb724883238293d568e521e5e2