### PR TITLE
Fix hero background layering on highlights page

### DIFF
--- a/src/pages/Highlights.jsx
+++ b/src/pages/Highlights.jsx
@@ -46,25 +46,30 @@ const Highlights = () => {
   }, []);
 
   return (
-    <section className="hero highlight-hero">
-      <div className="video-wrapper">
-        <video
-          className="hero-video"
-          src={highlightVideo}
-          autoPlay
-          loop
-          muted
-          playsInline
-          poster={heroPoster}
-        />
-      </div>
-      <div className="hero-overlay" />
-      <div className="hero-content">
-        <h1>Watch the Best of Mario Stroeykens</h1>
-        <p>
-          Explore Mario’s most electrifying moments—from his first senior goal to
-          jaw-dropping match-winners. Click any clip to relive the action in full.
-        </p>
+    <div>
+      <section className="hero highlight-hero">
+        <div className="video-wrapper">
+          <video
+            className="hero-video"
+            src={highlightVideo}
+            autoPlay
+            loop
+            muted
+            playsInline
+            poster={heroPoster}
+          />
+        </div>
+        <div className="hero-overlay" />
+        <div className="hero-content">
+          <h1>Watch the Best of Mario Stroeykens</h1>
+          <p>
+            Explore Mario’s most electrifying moments—from his first senior goal to
+            jaw-dropping match-winners. Click any clip to relive the action in full.
+          </p>
+        </div>
+      </section>
+      <div className="hero-divider" />
+      <div className="highlights">
         <div className="video-grid">
           {videos.map(v => (
             <div
@@ -89,7 +94,7 @@ const Highlights = () => {
           </div>
         )}
       </div>
-    </section>
+    </div>
   );
 };
 

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -6,7 +6,8 @@
   box-shadow: 0 4px 4px rgba(0,0,0,0.2);
 }
 .hero .video-wrapper {
-  position: relative;
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
 }
@@ -19,6 +20,7 @@
   height: 100%;
   object-fit: cover;
   object-position: center center;
+  z-index: 0;
 }
 
 .hero-overlay {
@@ -81,6 +83,8 @@
     width: calc(100% + 2rem);
   }
   .hero .video-wrapper {
+    position: absolute;
+    inset: 0;
     padding-bottom: 0;
     height: 100%;
   }

--- a/src/styles/highlights.css
+++ b/src/styles/highlights.css
@@ -1,4 +1,8 @@
 
+.highlights {
+  padding: 2rem;
+}
+
 .highlight-hero {
   height: auto;
   min-height: 100vh;
@@ -18,7 +22,7 @@
   text-align: center;
 }
 
-.highlight-hero .video-grid {
+.highlights .video-grid {
   margin-top: 2rem;
 }
 


### PR DESCRIPTION
## Summary
- ensure the background video sits behind content
- restore highlights layout with hero divider and grid section

## Testing
- `npm test` *(fails: react-scripts permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684efe3148988323ba942b8cea717081