### PR TITLE
Overlay highlight grid on hero video

### DIFF
--- a/src/pages/Highlights.jsx
+++ b/src/pages/Highlights.jsx
@@ -46,29 +46,26 @@ const Highlights = () => {
   }, []);
 
   return (
-    <div>
-      <section className="hero highlight-hero">
-        <div className="video-wrapper">
-          <video
-            className="hero-video"
-            src={highlightVideo}
-            autoPlay
-            loop
-            muted
-            playsInline
-            poster={heroPoster}
-          />
-        </div>
-        <div className="hero-overlay" />
-        <div className="hero-content">
-          <h1>Watch the Best of Mario Stroeykens</h1>
-          <p>
-            Explore Mario’s most electrifying moments—from his first senior goal to
-            jaw-dropping match-winners. Click any clip to relive the action in full.
-          </p>
-        </div>
-      </section>
-      <div className="hero-divider" />
+    <section className="hero highlight-hero">
+      <div className="video-wrapper">
+        <video
+          className="hero-video"
+          src={highlightVideo}
+          autoPlay
+          loop
+          muted
+          playsInline
+          poster={heroPoster}
+        />
+      </div>
+      <div className="hero-overlay" />
+      <div className="hero-content">
+        <h1>Watch the Best of Mario Stroeykens</h1>
+        <p>
+          Explore Mario’s most electrifying moments—from his first senior goal to
+          jaw-dropping match-winners. Click any clip to relive the action in full.
+        </p>
+      </div>
       <div className="highlights">
         <div className="video-grid">
           {videos.map(v => (
@@ -94,7 +91,7 @@ const Highlights = () => {
           </div>
         )}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/styles/highlights.css
+++ b/src/styles/highlights.css
@@ -3,12 +3,27 @@
   padding: 2rem;
 }
 
+
 .highlight-hero {
+  position: relative;
   height: auto;
   min-height: 100vh;
 }
 
+.highlight-hero .video-wrapper,
 .highlight-hero .hero-overlay {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.highlight-hero .video-wrapper {
+  z-index: -2;
+}
+
+.highlight-hero .hero-overlay {
+  z-index: -1;
   background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.9));
 }
 
@@ -20,6 +35,11 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
+}
+
+.highlight-hero .highlights {
+  position: relative;
+  z-index: 2;
 }
 
 .highlights .video-grid {


### PR DESCRIPTION
## Summary
- overlay the highlights grid on top of the hero video
- make highlight video act as a fixed background

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f005047ac832392ac445047951d4e